### PR TITLE
feat: audio meter, offline detection, better error handling

### DIFF
--- a/android/src/main/java/com/dbkable/reactnativespeechtotext/ReactNativeSpeechToTextModule.kt
+++ b/android/src/main/java/com/dbkable/reactnativespeechtotext/ReactNativeSpeechToTextModule.kt
@@ -1,9 +1,14 @@
 package com.dbkable.reactnativespeechtotext
 
 import android.Manifest
+import android.content.ComponentName
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.os.Bundle
+import android.provider.Settings
 import android.speech.RecognitionListener
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
@@ -53,9 +58,14 @@ class ReactNativeSpeechToTextModule(reactContext: ReactApplicationContext) :
       return
     }
 
+    if (isAirplaneModeEnabled(context) && isRecognizerOffline(context)) {
+      promise.reject("NETWORK_ERROR", "Network error")
+      return
+    }
+
     android.os.Handler(android.os.Looper.getMainLooper()).post {
       try {
-        speechRecognizer = SpeechRecognizer.createSpeechRecognizer(context)
+        speechRecognizer = createPreferredSpeechRecognizer(context)
 
         val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
           putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
@@ -70,7 +80,12 @@ class ReactNativeSpeechToTextModule(reactContext: ReactApplicationContext) :
         speechRecognizer?.setRecognitionListener(object : RecognitionListener {
           override fun onReadyForSpeech(params: Bundle?) {}
           override fun onBeginningOfSpeech() {}
-          override fun onRmsChanged(rmsdB: Float) {}
+          override fun onRmsChanged(rmsdB: Float) {
+            val level = ((rmsdB + 2f) / 14f).coerceIn(0f, 1f)
+            val event = Arguments.createMap()
+            event.putDouble("level", level.toDouble())
+            sendEvent("audioMeterUpdate", event)
+          }
           override fun onBufferReceived(buffer: ByteArray?) {}
 
           override fun onEndOfSpeech() {
@@ -87,6 +102,8 @@ class ReactNativeSpeechToTextModule(reactContext: ReactApplicationContext) :
                 return
               }
 
+              val isOffline = isRecognizerOffline(context)
+
               val errorCode = when (error) {
                 SpeechRecognizer.ERROR_AUDIO -> "AUDIO_ERROR"
                 SpeechRecognizer.ERROR_CLIENT -> "CLIENT_ERROR"
@@ -94,8 +111,14 @@ class ReactNativeSpeechToTextModule(reactContext: ReactApplicationContext) :
                 SpeechRecognizer.ERROR_NETWORK -> "NETWORK_ERROR"
                 SpeechRecognizer.ERROR_NETWORK_TIMEOUT -> "NETWORK_TIMEOUT"
                 SpeechRecognizer.ERROR_RECOGNIZER_BUSY -> "RECOGNIZER_BUSY"
-                SpeechRecognizer.ERROR_SERVER -> "SERVER_ERROR"
-                else -> "UNKNOWN_ERROR"
+                SpeechRecognizer.ERROR_SERVER -> if (isOffline) "NETWORK_ERROR" else "SERVER_ERROR"
+                SpeechRecognizer.ERROR_SERVER_DISCONNECTED -> "NETWORK_ERROR"
+                SpeechRecognizer.ERROR_TOO_MANY_REQUESTS -> if (isOffline) "NETWORK_ERROR" else "REQUEST_FAILED"
+                SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED,
+                SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE,
+                SpeechRecognizer.ERROR_CANNOT_CHECK_SUPPORT,
+                SpeechRecognizer.ERROR_CANNOT_LISTEN_TO_DOWNLOAD_EVENTS -> "NOT_AVAILABLE"
+                else -> if (isOffline) "NETWORK_ERROR" else "UNKNOWN_ERROR"
               }
 
               val errorMessage = when (error) {
@@ -105,8 +128,14 @@ class ReactNativeSpeechToTextModule(reactContext: ReactApplicationContext) :
                 SpeechRecognizer.ERROR_NETWORK -> "Network error"
                 SpeechRecognizer.ERROR_NETWORK_TIMEOUT -> "Network timeout"
                 SpeechRecognizer.ERROR_RECOGNIZER_BUSY -> "Recognizer busy"
-                SpeechRecognizer.ERROR_SERVER -> "Server error"
-                else -> "Unknown error"
+                SpeechRecognizer.ERROR_SERVER -> if (isOffline) "Network error" else "Server error"
+                SpeechRecognizer.ERROR_SERVER_DISCONNECTED -> "Speech service disconnected"
+                SpeechRecognizer.ERROR_TOO_MANY_REQUESTS -> if (isOffline) "Network error" else "Too many requests"
+                SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED -> "Language not supported"
+                SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE -> "Language unavailable"
+                SpeechRecognizer.ERROR_CANNOT_CHECK_SUPPORT -> "Cannot check language support"
+                SpeechRecognizer.ERROR_CANNOT_LISTEN_TO_DOWNLOAD_EVENTS -> "Cannot listen to language download events"
+                else -> if (isOffline) "Network error" else "Unknown error"
               }
 
               val event = Arguments.createMap()
@@ -222,6 +251,36 @@ class ReactNativeSpeechToTextModule(reactContext: ReactApplicationContext) :
       speechRecognizer?.destroy()
       speechRecognizer = null
     }
+  }
+
+  private fun createPreferredSpeechRecognizer(context: Context): SpeechRecognizer {
+    val preferredPackages = listOf(
+      "com.google.android.tts",
+      "com.google.android.googlequicksearchbox",
+    )
+    val pm = context.packageManager
+    for (pkg in preferredPackages) {
+      val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).setPackage(pkg)
+      val services = pm.queryIntentServices(intent, 0)
+      if (services.isNotEmpty()) {
+        val info = services[0].serviceInfo
+        return SpeechRecognizer.createSpeechRecognizer(context, ComponentName(info.packageName, info.name))
+      }
+    }
+    return SpeechRecognizer.createSpeechRecognizer(context)
+  }
+
+  private fun isRecognizerOffline(context: Context): Boolean {
+    val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+      ?: return false
+    val network = connectivityManager.activeNetwork ?: return true
+    val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return true
+    return !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) ||
+      !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+  }
+
+  private fun isAirplaneModeEnabled(context: Context): Boolean {
+    return Settings.Global.getInt(context.contentResolver, Settings.Global.AIRPLANE_MODE_ON, 0) == 1
   }
 
   companion object {

--- a/ios/ReactNativeSpeechToText.mm
+++ b/ios/ReactNativeSpeechToText.mm
@@ -33,7 +33,7 @@ RCT_EXPORT_MODULE(ReactNativeSpeechToText)
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-  return @[@"onSpeechResult", @"onSpeechError", @"onSpeechEnd"];
+  return @[@"onSpeechResult", @"onSpeechError", @"onSpeechEnd", @"audioMeterUpdate"];
 }
 
 - (void)startObserving {

--- a/ios/SpeechToText.swift
+++ b/ios/SpeechToText.swift
@@ -14,6 +14,7 @@ public class SpeechToTextImpl: NSObject {
   private var lastTranscript: String = ""
   private var lastConfidence: Double = 0.0
   private var isManuallyStopped: Bool = false
+  private var savedAudioSession: (category: AVAudioSession.Category, mode: AVAudioSession.Mode)?
 
   @objc public init(eventEmitter: RCTEventEmitter) {
     self.eventEmitter = eventEmitter
@@ -74,6 +75,7 @@ public class SpeechToTextImpl: NSObject {
 
     do {
       let audioSession = AVAudioSession.sharedInstance()
+      savedAudioSession = (audioSession.category, audioSession.mode)
       try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
       try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
 
@@ -88,8 +90,18 @@ public class SpeechToTextImpl: NSObject {
       let inputNode = audioEngine.inputNode
       let recordingFormat = inputNode.outputFormat(forBus: 0)
 
-      inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { buffer, _ in
+      guard recordingFormat.sampleRate > 0 && recordingFormat.channelCount > 0 else { return }
+
+      inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { [weak self] buffer, _ in
         recognitionRequest.append(buffer)
+        guard let channelData = buffer.floatChannelData?[0] else { return }
+        let frameLength = Int(buffer.frameLength)
+        guard frameLength > 0 else { return }
+        var sum: Float = 0
+        for i in 0..<frameLength { sum += channelData[i] * channelData[i] }
+        let rms = (sum / Float(frameLength)).squareRoot()
+        let level = Double(min(1.0, max(0.0, 1.0 + log10(max(Double(rms), 1e-7)) / 4.0)))
+        self?.sendEvent(name: "audioMeterUpdate", body: ["level": level])
       }
 
       audioEngine.prepare()
@@ -164,6 +176,10 @@ public class SpeechToTextImpl: NSObject {
     recognitionTask?.cancel()
     recognitionRequest = nil
     recognitionTask = nil
+    if let saved = savedAudioSession {
+      try? AVAudioSession.sharedInstance().setCategory(saved.category, mode: saved.mode)
+    }
+    try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
   }
 
   private func getConfidence(from result: SFSpeechRecognitionResult) -> Double {


### PR DESCRIPTION
Hey, thanks for this project. For context, I integrated this library while building a RN brownfield SDK where we didn't use expo. I ended up creating some patches, primarily around adding more feedback and audio metering. Feel free to close it, just thought I'd leave them here in case you ever want to push a new version.

**Audio meter**
- `audioMeterUpdate` event with normalized 0-1 level
- Android: computed from `onRmsChanged`
- iOS: RMS from audio buffer tap

**Offline detection**
- Checks airplane mode + network before starting
- Rejects with `NETWORK_ERROR` when offline
- Maps `ERROR_SERVER`, `ERROR_TOO_MANY_REQUESTS`, unknown errors to `NETWORK_ERROR` when offline

**Error code mapping**
- `ERROR_SERVER_DISCONNECTED` → `NETWORK_ERROR`
- `ERROR_LANGUAGE_NOT_SUPPORTED`, `ERROR_LANGUAGE_UNAVAILABLE`, `ERROR_CANNOT_CHECK_SUPPORT`, `ERROR_CANNOT_LISTEN_TO_DOWNLOAD_EVENTS` → `NOT_AVAILABLE`
- `ERROR_TOO_MANY_REQUESTS` → `REQUEST_FAILED`

**Preferred recognizer**
- Tries Google TTS and Google Search recognizers first

**iOS cleanup**
- Saves/restores audio session category+mode on stop
- Crash guard for zero sample rate / channel count

Cheers